### PR TITLE
Add rely tests to template

### DIFF
--- a/assets/pesy-Test.template.re
+++ b/assets/pesy-Test.template.re
@@ -1,2 +1,18 @@
-Library.Util.foo();
-print_endline("Add Your Test Cases Here");
+module TestFramework =
+  Rely.Make({
+    let config =
+      Rely.TestFrameworkConfig.initialize({
+        snapshotDir: "test/_snapshots",
+        projectDir: "",
+      });
+  });
+
+open TestFramework;
+
+describe("my first test suite", ({test}) =>
+  test("1 + 1 should equal 2", ({expect}) =>
+    expect.int(1 + 1).toBe(2)
+  )
+);
+
+cli();

--- a/assets/pesy-package.template.json
+++ b/assets/pesy-package.template.json
@@ -5,20 +5,17 @@
   "esy": {
     "build": "dune build -p #{self.name}",
     "release": {
-      "releasedBinaries": [
-        "<PACKAGE_NAME_UPPER_CAMEL>App.exe"
-      ]
+      "releasedBinaries": ["<PACKAGE_NAME_UPPER_CAMEL>App.exe"]
     }
   },
   "buildDirs": {
     "test": {
-      "require": ["<PUBLIC_LIB_NAME>"],
+      "require": ["<PUBLIC_LIB_NAME>", "rely.lib"],
       "bin": {
         "Test<PACKAGE_NAME_UPPER_CAMEL>.exe": "Test<PACKAGE_NAME_UPPER_CAMEL>.re"
       }
     },
-    "library": {
-    },
+    "library": {},
     "executable": {
       "require": ["<PUBLIC_LIB_NAME>"],
       "bin": {
@@ -34,7 +31,8 @@
     "@esy-ocaml/reason": "*",
     "refmterr": "*",
     "ocaml": "~4.6.0",
-    "pesy": "*"
+    "pesy": "*",
+    "@reason-native/rely": "*"
   },
   "devDependencies": {
     "@opam/merlin": "*"


### PR DESCRIPTION
This is the smallest thing possible that I could come up with.

In a real world scenario we probably want to break out the `TestFramework` module to its own file. We probably also want to have a `link-all` flag possible so that each test can be in its own file without getting optimised away.