### PR TITLE
Remove pesy-self. Since pesy is a dev dependency

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f504e64c05260e635db88c4c828dfc7b",
+  "checksum": "3e92c1bef1e975e66c18237b8f090a20",
   "root": "pesy@link-dev:./package.json",
   "node": {
     "refmterr@3.1.10@d41d8cd9": {
@@ -19,31 +19,6 @@
       ],
       "devDependencies": []
     },
-    "pesy-self@github:esy/pesy#fde323697a0357003d16fb6e057d7c7b0ee293fd@d41d8cd9": {
-      "id":
-        "pesy-self@github:esy/pesy#fde323697a0357003d16fb6e057d7c7b0ee293fd@d41d8cd9",
-      "name": "pesy-self",
-      "version": "github:esy/pesy#fde323697a0357003d16fb6e057d7c7b0ee293fd",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy/pesy#fde323697a0357003d16fb6e057d7c7b0ee293fd"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "refmterr@3.1.10@d41d8cd9", "ocaml@4.6.10@d41d8cd9",
-        "dune@0.2.1@d41d8cd9",
-        "@reason-native/pastel@github:facebookexperimental/reason-native#028b0973b0268530609c3edfa4b4f3ebbf9fbb43@d41d8cd9",
-        "@opam/yojson@opam:1.7.0@2d92307e",
-        "@opam/sexplib@opam:v0.11.0@bf5282c9",
-        "@opam/ppx_inline_test@opam:v0.11.0@b987f92a",
-        "@opam/ppx_expect@opam:v0.11.1@406d6035",
-        "@opam/fpath@opam:0.7.2@45477b93", "@opam/dune@opam:1.8.2@511996a8",
-        "@opam/bos@opam:0.2.0@df49e63f", "@esy-ocaml/reason@3.4.0@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "pesy@link-dev:./package.json": {
       "id": "pesy@link-dev:./package.json",
       "name": "pesy",
@@ -55,9 +30,8 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.1.10@d41d8cd9",
-        "pesy-self@github:esy/pesy#fde323697a0357003d16fb6e057d7c7b0ee293fd@d41d8cd9",
-        "ocaml@4.6.10@d41d8cd9", "dune@0.2.1@d41d8cd9",
+        "refmterr@3.1.10@d41d8cd9", "ocaml@4.6.10@d41d8cd9",
+        "dune@0.2.1@d41d8cd9",
         "@reason-native/pastel@github:facebookexperimental/reason-native#028b0973b0268530609c3edfa4b4f3ebbf9fbb43@d41d8cd9",
         "@opam/yojson@opam:1.7.0@2d92307e",
         "@opam/sexplib@opam:v0.11.0@bf5282c9",
@@ -219,7 +193,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.6.10@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -325,7 +299,7 @@
       "dependencies": [
         "ocaml@4.6.10@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
         "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -761,8 +735,8 @@
         "ocaml@4.6.10@d41d8cd9", "@opam/sexplib0@opam:v0.11.0@9df6bcd1"
       ]
     },
-    "@opam/ocamlfind@opam:1.8.0@4eaa30d0": {
-      "id": "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+    "@opam/ocamlfind@opam:1.8.0@f744a0c5": {
+      "id": "@opam/ocamlfind@opam:1.8.0@f744a0c5",
       "name": "@opam/ocamlfind",
       "version": "opam:1.8.0",
       "source": {
@@ -890,7 +864,7 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.6.10@d41d8cd9" ]
@@ -918,7 +892,7 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/cppo@opam:1.6.5@bec3dbd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.6.10@d41d8cd9" ]
@@ -942,12 +916,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.6.10@d41d8cd9", "@opam/yojson@opam:1.7.0@2d92307e",
-        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/dune@opam:1.8.2@511996a8", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.6.10@d41d8cd9", "@opam/yojson@opam:1.7.0@2d92307e",
-        "@opam/ocamlfind@opam:1.8.0@4eaa30d0"
+        "@opam/ocamlfind@opam:1.8.0@f744a0c5"
       ]
     },
     "@opam/menhir@opam:20181113@0c8257a8": {
@@ -968,7 +942,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -994,7 +968,7 @@
       "dependencies": [
         "ocaml@4.6.10@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
         "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/fmt@opam:0.8.5@01e38a4e", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
@@ -1044,7 +1018,7 @@
       "dependencies": [
         "ocaml@4.6.10@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
         "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/astring@opam:0.8.3@4e5e17d5",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1074,7 +1048,7 @@
       "dependencies": [
         "ocaml@4.6.10@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/topkg@opam:1.0.0@61f4ccf9", "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1249,7 +1223,7 @@
       "dependencies": [
         "ocaml@4.6.10@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
         "@opam/rresult@opam:0.6.0@4b185e72",
-        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/logs@opam:0.6.2@8f7a792d", "@opam/fpath@opam:0.7.2@45477b93",
         "@opam/fmt@opam:0.8.5@01e38a4e",
@@ -1341,11 +1315,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@4eaa30d0"
+        "ocaml@4.6.10@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5"
       ]
     },
     "@opam/base@opam:v0.11.1@6ff71eb3": {
@@ -1484,7 +1458,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.6.10@d41d8cd9", "@opam/topkg@opam:1.0.0@61f4ccf9",
-        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocamlbuild@opam:0.14.0@427a2331",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1520,7 +1494,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.6.10@d41d8cd9", "@opam/result@opam:1.3@bee8bf2e",
-        "@opam/ocamlfind@opam:1.8.0@4eaa30d0",
+        "@opam/ocamlfind@opam:1.8.0@f744a0c5",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/merlin-extend@opam:0.3@e1fc0d08",
         "@opam/menhir@opam:20181113@0c8257a8",

--- a/esy.lock/opam/ocamlfind.1.8.0/opam
+++ b/esy.lock/opam/ocamlfind.1.8.0/opam
@@ -16,6 +16,7 @@ build: [
     "-config"
     "%{lib}%/findlib.conf"
     "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "all"]
@@ -37,6 +38,7 @@ remove: [
     man
     "-config"
     "%{lib}%/findlib.conf"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
     "-no-topfind" {ocaml:preinstalled}
   ]
   [make "uninstall"]

--- a/package.json
+++ b/package.json
@@ -82,14 +82,12 @@
     "@reason-native/pastel": "^0.2.0",
     "dune": "^0.2.1",
     "ocaml": "~4.6.0",
-    "refmterr": "*",
-    "pesy-self": "*"
+    "refmterr": "*"
   },
   "devDependencies": {
     "@opam/merlin": "*"
   },
   "resolutions": {
-    "@reason-native/pastel": "facebookexperimental/reason-native#028b0973b0268530609c3edfa4b4f3ebbf9fbb43",
-    "pesy-self": "esy/pesy#fde323697a0357003d16fb6e057d7c7b0ee293fd"
+    "@reason-native/pastel": "facebookexperimental/reason-native#028b0973b0268530609c3edfa4b4f3ebbf9fbb43"
   }
 }


### PR DESCRIPTION
pesy will be needed only during development. And dune files
will be committed. Pesy doesn't need to be pinned to github