### PR TITLE
Update Rely Setup

### DIFF
--- a/assets/dune
+++ b/assets/dune
@@ -2,15 +2,17 @@
    (name PesyAssets)
    (public_name pesy.assets)
 )
- 
+
 (install
  (section share_root)
- (files 
+ (files
          (pesy-package.template.json as template-repo/pesy-package.template.json)
          (pesy-gitignore.template as template-repo/pesy-gitignore.template)
          (pesy-Util.template.re as template-repo/pesy-Util.template.re)
          (pesy-README.template.md as template-repo/pesy-README.template.md)
          (pesy-Test.template.re as template-repo/pesy-Test.template.re)
+         (pesy-TestFramework.template.re as template-repo/pesy-TestFramework.template.re)
+         (pesy-RunTests.template.re as template-repo/pesy-RunTests.template.re)
          (pesy-App.template.re as template-repo/pesy-App.template.re)
          (azure-pipeline-templates/pesy-azure-pipelines.yml as template-repo/azure-pipeline-templates/pesy-azure-pipelines.yml)
          (azure-pipeline-templates/pesy-esy-build-steps.template.yml as template-repo/azure-pipeline-templates/pesy-esy-build-steps.template.yml)

--- a/assets/pesy-RunTests.template.re
+++ b/assets/pesy-RunTests.template.re
@@ -1,0 +1,1 @@
+Test.TestFramework.cli();

--- a/assets/pesy-Test.template.re
+++ b/assets/pesy-Test.template.re
@@ -1,12 +1,3 @@
-module TestFramework =
-  Rely.Make({
-    let config =
-      Rely.TestFrameworkConfig.initialize({
-        snapshotDir: "test/_snapshots",
-        projectDir: "",
-      });
-  });
-
 open TestFramework;
 
 describe("my first test suite", ({test, _}) =>
@@ -14,5 +5,3 @@ describe("my first test suite", ({test, _}) =>
     expect.int(1 + 1).toBe(2)
   )
 );
-
-cli();

--- a/assets/pesy-TestFramework.template.re
+++ b/assets/pesy-TestFramework.template.re
@@ -1,0 +1,7 @@
+include Rely.Make({
+    let config =
+      Rely.TestFrameworkConfig.initialize({
+        snapshotDir: "test/_snapshots",
+        projectDir: "",
+      });
+  });

--- a/assets/pesy-package.template.json
+++ b/assets/pesy-package.template.json
@@ -16,7 +16,7 @@
     "testExe": {
       "require": ["<TEST_LIB_NAME>"],
       "bin": {
-        "RunTests.exe": "RunTests.re"
+        "Run<PACKAGE_NAME_UPPER_CAMEL>Tests.exe": "Run<PACKAGE_NAME_UPPER_CAMEL>Tests.re"
       }
     },
     "library": {},
@@ -28,7 +28,7 @@
     }
   },
   "scripts": {
-    "test": "esy x RunTests.exe"
+    "test": "esy x Run<PACKAGE_NAME_UPPER_CAMEL>Tests.exe"
   },
   "dependencies": {
     "@opam/dune": "*",

--- a/assets/pesy-package.template.json
+++ b/assets/pesy-package.template.json
@@ -11,8 +11,12 @@
   "buildDirs": {
     "test": {
       "require": ["<PUBLIC_LIB_NAME>", "rely.lib"],
+      "flags": ["-linkall", "-g"]
+    },
+    "testExe": {
+      "require": ["<TEST_LIB_NAME>"],
       "bin": {
-        "Test<PACKAGE_NAME_UPPER_CAMEL>.exe": "Test<PACKAGE_NAME_UPPER_CAMEL>.re"
+        "RunTests.exe": "RunTests.re"
       }
     },
     "library": {},
@@ -24,7 +28,7 @@
     }
   },
   "scripts": {
-    "test": "esy b dune runtest"
+    "test": "esy x RunTests.exe"
   },
   "dependencies": {
     "@opam/dune": "*",

--- a/lib/Lib.re
+++ b/lib/Lib.re
@@ -88,7 +88,9 @@ let bootstrapIfNecessary = projectPath => {
     ();
   };
 
-  let runTestsPath = Path.(testExeDir / "RunTests.re");
+  let testExeFileName =
+    "Run<PACKAGE_NAME_UPPER_CAMEL>Tests.re" |> substituteTemplateValues;
+  let runTestsPath = Path.(testExeDir / testExeFileName);
   if (!exists(runTestsPath)) {
     let runTests = runTestsTemplate |> substituteTemplateValues;
 

--- a/lib/Lib.re
+++ b/lib/Lib.re
@@ -15,6 +15,8 @@ let bootstrapIfNecessary = projectPath => {
   let packageJSONTemplate = loadTemplate("pesy-package.template.json");
   let appReTemplate = loadTemplate("pesy-App.template.re");
   let testReTemplate = loadTemplate("pesy-Test.template.re");
+  let runTestsTemplate = loadTemplate("pesy-RunTests.template.re");
+  let testFrameworkTemplate = loadTemplate("pesy-TestFramework.template.re");
   let utilRe = loadTemplate("pesy-Util.template.re");
   let readMeTemplate = loadTemplate("pesy-README.template.md");
   let gitignoreTemplate = loadTemplate("pesy-gitignore.template");
@@ -23,17 +25,22 @@ let bootstrapIfNecessary = projectPath => {
       Path.("azure-pipeline-templates" / "pesy-esy-build-steps.template.yml"),
     );
   let packageLibName = packageNameKebabSansScope ++ "/library";
+  let packageTestName = packageNameKebabSansScope ++ "/test";
+
+  let substituteTemplateValues = s =>
+    s
+    |> Str.global_replace(r("<PACKAGE_NAME_FULL>"), packageNameKebab)
+    |> Str.global_replace(r("<VERSION>"), version)
+    |> Str.global_replace(r("<PUBLIC_LIB_NAME>"), packageLibName)
+    |> Str.global_replace(r("<TEST_LIB_NAME>"), packageTestName)
+    |> Str.global_replace(r("<PACKAGE_NAME>"), packageNameKebab)
+    |> Str.global_replace(
+         r("<PACKAGE_NAME_UPPER_CAMEL>"),
+         packageNameUpperCamelCase,
+       );
 
   if (!exists("package.json")) {
-    let packageJSON =
-      packageJSONTemplate
-      |> Str.global_replace(r("<PACKAGE_NAME_FULL>"), packageNameKebab)
-      |> Str.global_replace(r("<VERSION>"), version)
-      |> Str.global_replace(r("<PUBLIC_LIB_NAME>"), packageLibName)
-      |> Str.global_replace(
-           r("<PACKAGE_NAME_UPPER_CAMEL>"),
-           packageNameUpperCamelCase,
-         );
+    let packageJSON = packageJSONTemplate |> substituteTemplateValues;
     write("package.json", packageJSON);
   };
 
@@ -41,12 +48,7 @@ let bootstrapIfNecessary = projectPath => {
   let appRePath = Path.(appReDir / packageNameUpperCamelCase ++ "App.re");
 
   if (!exists(appRePath)) {
-    let appRe =
-      Str.global_replace(
-        r("<PACKAGE_NAME_UPPER_CAMEL>"),
-        packageNameUpperCamelCase,
-        appReTemplate,
-      );
+    let appRe = appReTemplate |> substituteTemplateValues;
     let _ = mkdirp(appReDir);
     write(appRePath, appRe);
   };
@@ -60,58 +62,60 @@ let bootstrapIfNecessary = projectPath => {
   };
 
   let testReDir = Path.(projectPath / "test");
+
+  if (!exists(testReDir)) {
+    let _ = mkdirp(testReDir);
+    ();
+  };
+
   let testRePath =
     Path.(testReDir / "Test" ++ packageNameUpperCamelCase ++ ".re");
 
   if (!exists(testRePath)) {
-    let testRe =
-      Str.global_replace(
-        r("<PACKAGE_NAME_UPPER_CAMEL>"),
-        packageNameUpperCamelCase,
-        testReTemplate,
-      );
-    let _ = mkdirp(testReDir);
+    let testRe = testReTemplate |> substituteTemplateValues;
     write(testRePath, testRe);
+  };
+
+  let testFrameworkPath = Path.(testReDir / "TestFramework.re");
+  if (!exists(testFrameworkPath)) {
+    let testFramework = testFrameworkTemplate |> substituteTemplateValues;
+    write(testFrameworkPath, testFramework);
+  };
+
+  let testExeDir = Path.(projectPath / "testExe");
+  if (!exists(testExeDir)) {
+    let _ = mkdirp(testExeDir);
+    ();
+  };
+
+  let runTestsPath = Path.(testExeDir / "RunTests.re");
+  if (!exists(runTestsPath)) {
+    let runTests = runTestsTemplate |> substituteTemplateValues;
+
+    write(runTestsPath, runTests);
   };
 
   let readMePath = Path.(projectPath / "README.md");
 
   if (!exists(readMePath)) {
-    let readMe =
-      readMeTemplate
-      |> Str.global_replace(r("<PACKAGE_NAME_FULL>"), packageNameKebab)
-      |> Str.global_replace(r("<PACKAGE_NAME>"), packageNameKebab)
-      |> Str.global_replace(r("<PUBLIC_LIB_NAME>"), packageLibName)
-      |> Str.global_replace(
-           r("<PACKAGE_NAME_UPPER_CAMEL>"),
-           packageNameUpperCamelCase,
-         );
+    let readMe = readMeTemplate |> substituteTemplateValues;
+
     write(readMePath, readMe);
   };
 
   let gitignorePath = Path.(projectPath / ".gitignore");
 
   if (!exists(gitignorePath)) {
-    let gitignore =
-      gitignoreTemplate
-      |> Str.global_replace(r("<PACKAGE_NAME>"), packageNameKebab)
-      |> Str.global_replace(r("<PUBLIC_LIB_NAME>"), packageLibName)
-      |> Str.global_replace(
-           r("<PACKAGE_NAME_UPPER_CAMEL>"),
-           packageNameUpperCamelCase,
-         );
+    let gitignore = gitignoreTemplate |> substituteTemplateValues;
+
     write(".gitignore", gitignore);
   };
 
   let azurePipelinesPath = Path.(projectPath / "azure-pipelines.yml");
 
   if (!exists(azurePipelinesPath)) {
-    let esyBuildSteps =
-      esyBuildStepsTemplate
-      |> Str.global_replace(
-           r("<PACKAGE_NAME_UPPER_CAMEL>"),
-           packageNameUpperCamelCase,
-         );
+    let esyBuildSteps = esyBuildStepsTemplate |> substituteTemplateValues;
+
     copyTemplate(
       Path.("azure-pipeline-templates" / "pesy-azure-pipelines.yml"),
       Path.(projectPath / "azure-pipelines.yml"),

--- a/lib/PesyConf.re
+++ b/lib/PesyConf.re
@@ -712,7 +712,7 @@ let%expect_test _ = {
   List.iter(print_endline, List.map(DuneFile.toString, duneFiles));
   %expect
   {|
-     (test (name Bar) (libraries foo))
+     (executable (name Bar) (public_name Bar.exe) (libraries foo))
    |};
 };
 

--- a/lib/PesyConf.re
+++ b/lib/PesyConf.re
@@ -251,8 +251,6 @@ let toPesyConf = (projectPath: string, json: JSON.t): t => {
       pkg => {
         let (dir, conf) = pkg;
 
-        let isTestRunner = dir == "test";
-
         let binJSON = JSON.member(conf, "bin");
         let bin =
           try (
@@ -417,64 +415,7 @@ let toPesyConf = (projectPath: string, json: JSON.t): t => {
           | _ => None
           };
 
-        if (isTestRunner) {
-          let main =
-            switch (bin) {
-            | Some((mainFileName, _installedBinaryName)) =>
-              moduleNameOf(mainFileName)
-
-            | _ =>
-              try (
-                JSON.member(conf, "main")
-                |> JSON.toValue
-                |> FieldTypes.toString
-              ) {
-              | JSON.NullJSONValue () =>
-                raise(
-                  FatalError(
-                    sprintf(
-                      "Atleast one of `bin` or `main` must be provided for %s",
-                      dir,
-                    ),
-                  ),
-                )
-              | e => raise(e)
-              }
-            };
-
-          let modes =
-            try (
-              Some(
-                Test.Mode.ofList(
-                  JSON.member(conf, "modes")
-                  |> JSON.toValue
-                  |> FieldTypes.toList
-                  |> List.map(a => a |> FieldTypes.toString),
-                ),
-              )
-            ) {
-            | JSON.NullJSONValue () => None
-            | e => raise(e)
-            };
-
-          {
-            common:
-              Common.create(
-                name,
-                Path.(projectPath / dir),
-                require,
-                flags,
-                ocamlcFlags,
-                ocamloptFlags,
-                jsooFlags,
-                preprocess,
-                includeSubdirs,
-                rawBuildConfig,
-                rawBuildConfigFooter,
-              ),
-            pkgType: TestPackage(Test.create(main, modes)),
-          };
-        } else if (isBinPropertyPresent(bin)) {
+        if (isBinPropertyPresent(bin)) {
           /* Prioritising `bin` over `name` */
           let main =
             switch (bin) {


### PR DESCRIPTION
This separates the current Test.re file into three separate files and the current test project into a library and an executable so that the linkall flag can be used to improve developer experience when it comes to associating tests with the framework. Additionally I changed Pesy to no longer use the Test stanza/dune runtest due to the output swallowing behavior.

It looks like .re files written from the templates have a leading blank newline, however this was not introduced by my change (I verified that this happened with current master as well).

I tested this by running:
```
npm pack
tar -zxvf pesy-whatever
cd package
esy install
esy x (which pesy)
```
and then using the location from the esy x command to install a new project.

Currently when running this against an existing project it looks like that TestFramework.re and testExe/RunTests.re are created, but nothing gets overwritten. I'm not sure how we want to handle this incompatibility (FWIW existing tests still run, there are just new files that do nothing). I think figuring out what we want to do here is the only open question.