### PR TITLE
Use pesy as a dev dependency

### DIFF
--- a/assets/pesy-package.template.json
+++ b/assets/pesy-package.template.json
@@ -33,12 +33,12 @@
   "dependencies": {
     "@opam/dune": "*",
     "@esy-ocaml/reason": "*",
-    "refmterr": "*",
     "ocaml": "4.7.x",
-    "pesy": "*",
     "@reason-native/rely": "*"
   },
   "devDependencies": {
+    "refmterr": "*",
+    "pesy": "*",
     "@opam/merlin": "*"
   },
   "resolutions": {

--- a/esy.lock/.gitattributes
+++ b/esy.lock/.gitattributes
@@ -1,3 +1,3 @@
 
 # Set eol to LF so files aren't converted to CRLF-eol on Windows.
-* text eol=lf
+* text eol=lf linguist-generated

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9aa1911bc929e58fd5e93109008a88cf",
+  "checksum": "50c1385e686999d048d9772661872fad",
   "root": "pesy@link-dev:./package.json",
   "node": {
     "refmterr@3.1.10@d41d8cd9": {
@@ -16,6 +16,26 @@
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/re@opam:1.9.0@7f4a36a5",
         "@opam/dune@link:vendor/dune/dune.opam",
+        "@esy-ocaml/reason@3.4.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "pesy-self@github:esy/pesy#75d62cfc@d41d8cd9": {
+      "id": "pesy-self@github:esy/pesy#75d62cfc@d41d8cd9",
+      "name": "pesy-self",
+      "version": "github:esy/pesy#75d62cfc",
+      "source": {
+        "type": "install",
+        "source": [ "github:esy/pesy#75d62cfc" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9",
+        "@reason-native/pastel@link:vendor/reason-native/pastel.json",
+        "@opam/yojson@link:vendor/yojson/yojson.opam",
+        "@opam/sexplib@link:vendor/sexplib/sexplib.opam",
+        "@opam/dune@link:vendor/dune/dune.opam",
+        "@opam/cmdliner@link:vendor/cmdliner/cmdliner.opam",
         "@esy-ocaml/reason@3.4.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -40,7 +60,9 @@
         "@esy-ocaml/reason@3.4.0@d41d8cd9"
       ],
       "devDependencies": [
-        "refmterr@3.1.10@d41d8cd9", "@opam/merlin@opam:3.3.1@43415979"
+        "refmterr@3.1.10@d41d8cd9",
+        "pesy-self@github:esy/pesy#75d62cfc@d41d8cd9",
+        "@opam/merlin@opam:3.3.1@43415979"
       ]
     },
     "ocaml@4.7.1004@d41d8cd9": {
@@ -282,7 +304,7 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/conf-m4@opam:1@dd7dde42",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/conf-m4@opam:1@da6f4f44",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
@@ -314,20 +336,20 @@
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
     },
-    "@opam/ocaml-migrate-parsetree@opam:1.3.1@266527bd": {
-      "id": "@opam/ocaml-migrate-parsetree@opam:1.3.1@266527bd",
+    "@opam/ocaml-migrate-parsetree@opam:1.4.0@107a1ff4": {
+      "id": "@opam/ocaml-migrate-parsetree@opam:1.4.0@107a1ff4",
       "name": "@opam/ocaml-migrate-parsetree",
-      "version": "opam:1.3.1",
+      "version": "opam:1.4.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/83/83e4955a6fd6b494646ab92c476840ea96b5fb434435c287e7ad3e6efadc8338#sha256:83e4955a6fd6b494646ab92c476840ea96b5fb434435c287e7ad3e6efadc8338",
-          "archive:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.3.1/ocaml-migrate-parsetree-v1.3.1.tbz#sha256:83e4955a6fd6b494646ab92c476840ea96b5fb434435c287e7ad3e6efadc8338"
+          "archive:https://opam.ocaml.org/cache/sha256/23/231fbdc205187b3ee266b535d9cfe44b599067b2f6e97883c782ea7bb577d3b8#sha256:231fbdc205187b3ee266b535d9cfe44b599067b2f6e97883c782ea7bb577d3b8",
+          "archive:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.4.0/ocaml-migrate-parsetree-v1.4.0.tbz#sha256:231fbdc205187b3ee266b535d9cfe44b599067b2f6e97883c782ea7bb577d3b8"
         ],
         "opam": {
           "name": "ocaml-migrate-parsetree",
-          "version": "1.3.1",
-          "path": "esy.lock/opam/ocaml-migrate-parsetree.1.3.1"
+          "version": "1.4.0",
+          "path": "esy.lock/opam/ocaml-migrate-parsetree.1.4.0"
         }
       },
       "overrides": [],
@@ -423,20 +445,20 @@
         "@opam/ocamlfind@opam:1.8.0@f744a0c5"
       ]
     },
-    "@opam/menhir@opam:20190620@a914c43f": {
-      "id": "@opam/menhir@opam:20190620@a914c43f",
+    "@opam/menhir@opam:20190626@bbeb8953": {
+      "id": "@opam/menhir@opam:20190626@bbeb8953",
       "name": "@opam/menhir",
-      "version": "opam:20190620",
+      "version": "opam:20190626",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/f7/f77d327a6203dfa031a9b94466b0c560#md5:f77d327a6203dfa031a9b94466b0c560",
-          "archive:https://gitlab.inria.fr/fpottier/menhir/repository/20190620/archive.tar.gz#md5:f77d327a6203dfa031a9b94466b0c560"
+          "archive:https://opam.ocaml.org/cache/md5/78/783961f8d124449a1a335cc8e50f013f#md5:783961f8d124449a1a335cc8e50f013f",
+          "archive:https://gitlab.inria.fr/fpottier/menhir/repository/20190626/archive.tar.gz#md5:783961f8d124449a1a335cc8e50f013f"
         ],
         "opam": {
           "name": "menhir",
-          "version": "20190620",
-          "path": "esy.lock/opam/menhir.20190620"
+          "version": "20190626",
+          "path": "esy.lock/opam/menhir.20190626"
         }
       },
       "overrides": [],
@@ -538,8 +560,8 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/conf-which@opam:1@56319cdb": {
-      "id": "@opam/conf-which@opam:1@56319cdb",
+    "@opam/conf-which@opam:1@576f0c6d": {
+      "id": "@opam/conf-which@opam:1@576f0c6d",
       "name": "@opam/conf-which",
       "version": "opam:1",
       "source": {
@@ -555,8 +577,8 @@
       "dependencies": [ "@esy-ocaml/substs@0.0.1@d41d8cd9" ],
       "devDependencies": []
     },
-    "@opam/conf-m4@opam:1@dd7dde42": {
-      "id": "@opam/conf-m4@opam:1@dd7dde42",
+    "@opam/conf-m4@opam:1@da6f4f44": {
+      "id": "@opam/conf-m4@opam:1@da6f4f44",
       "name": "@opam/conf-m4",
       "version": "opam:1",
       "source": {
@@ -607,7 +629,7 @@
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/easy-format@opam:1.3.1@9abfd4ed",
-        "@opam/conf-which@opam:1@56319cdb",
+        "@opam/conf-which@opam:1@576f0c6d",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -702,9 +724,9 @@
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@7add0d71",
         "@opam/ocamlfind@opam:1.8.0@f744a0c5",
-        "@opam/ocaml-migrate-parsetree@opam:1.3.1@266527bd",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@107a1ff4",
         "@opam/merlin-extend@opam:0.4@9e025201",
-        "@opam/menhir@opam:20190620@a914c43f",
+        "@opam/menhir@opam:20190626@bbeb8953",
         "@opam/dune@link:vendor/dune/dune.opam"
       ],
       "devDependencies": []

--- a/esy.lock/opam/conf-m4.1/opam
+++ b/esy.lock/opam/conf-m4.1/opam
@@ -6,8 +6,7 @@ authors: "GNU Project"
 license: "GPL-3"
 build: [["sh" "-exc" "echo | m4"]]
 depexts: [
-  ["m4"] {os-distribution = "debian"}
-  ["m4"] {os-distribution = "ubuntu"}
+  ["m4"] {os-family = "debian"}
   ["m4"] {os-distribution = "fedora"}
   ["m4"] {os-distribution = "rhel"}
   ["m4"] {os-distribution = "centos"}

--- a/esy.lock/opam/conf-which.1/opam
+++ b/esy.lock/opam/conf-which.1/opam
@@ -9,8 +9,7 @@ depexts: [
   ["which"] {os-distribution = "centos"}
   ["which"] {os-distribution = "fedora"}
   ["which"] {os-family = "suse"}
-  ["debianutils"] {os-distribution = "debian"}
-  ["debianutils"] {os-distribution = "ubuntu"}
+  ["debianutils"] {os-family = "debian"}
   ["which"] {os-distribution = "nixos"}
   ["which"] {os-distribution = "arch"}
 ]

--- a/esy.lock/opam/menhir.20190626/opam
+++ b/esy.lock/opam/menhir.20190626/opam
@@ -21,9 +21,9 @@ depends: [
 synopsis: "An LR(1) parser generator"
 url {
   src:
-    "https://gitlab.inria.fr/fpottier/menhir/repository/20190620/archive.tar.gz"
+    "https://gitlab.inria.fr/fpottier/menhir/repository/20190626/archive.tar.gz"
   checksum: [
-    "md5=f77d327a6203dfa031a9b94466b0c560"
-    "sha512=7f21e60353219a70a3a037a1e77422aa11465d532335114b184dcefb5570c88070cb2f052351710dd13adcd3c0a15a3e8439b41b8ba4583dab71f6ce26d397f0"
+    "md5=783961f8d124449a1a335cc8e50f013f"
+    "sha512=bacc5161682130d894a6476fb79363aa73e5582543265a0c23c9a1f9d974007c04853dc8f6faa2b8bd2e82b2323b8604dcc4cb74308af667698079b394dfd492"
   ]
 }

--- a/esy.lock/opam/ocaml-migrate-parsetree.1.4.0/opam
+++ b/esy.lock/opam/ocaml-migrate-parsetree.1.4.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "result"
   "ppx_derivers"
-  "dune" {build & >= "1.6.0"}
+  "dune" {build & >= "1.9.0"}
   "ocaml" {>= "4.02.3"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
@@ -29,9 +29,9 @@ rewriters independent of a compiler version.
 """
 url {
   src:
-    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.3.1/ocaml-migrate-parsetree-v1.3.1.tbz"
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.4.0/ocaml-migrate-parsetree-v1.4.0.tbz"
   checksum: [
-    "sha256=83e4955a6fd6b494646ab92c476840ea96b5fb434435c287e7ad3e6efadc8338"
-    "sha512=7da86f9596dd1439990a6f087fdeba64a0f3ce2634473be4cca92ecc02b6fcd97917956890fbe35b3cba5a126d007afec6ede1e4afd0a5218c89fd6079ad4182"
+    "sha256=231fbdc205187b3ee266b535d9cfe44b599067b2f6e97883c782ea7bb577d3b8"
+    "sha512=61ee91d2d146cc2d2ff2d5dc4ef5dea4dc4d3c8dbd8b4c9586d64b6ad7302327ab35547aa0a5b0103c3f07b66b13d416a1bee6d4d117293cd3cabe44113ec6d4"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "ocaml": "4.7.x"
   },
   "devDependencies": {
+    "pesy-self": "esy/pesy#75d62cfc",
     "refmterr": "*",
     "@opam/merlin": "*"
   },


### PR DESCRIPTION
See https://github.com/jchavarri/rebez/issues/4

"This is probably due to stale dune files: pesy must have marked dune files as stale after it updated. But the problem can be avoided by using pesy a bit differently.

Pesy is right now caught in between being a build tool and a config manager. It doesn't function to it full potential as a build tool as it doesn't work closely with dune enough (for instance it is forced to create dune files in source). So it's best left to just manage config for you.

This means, we now use pesy only to generated config files for the project (dune and CI). We can now move pesy to devDependencies, thereby ensuring packages that consume rebez don't have to pull pesy."