### PR TITLE
Ignore destructuring warning in tests

### DIFF
--- a/npm-cli/share/template-repo/pesy-package.template.json
+++ b/npm-cli/share/template-repo/pesy-package.template.json
@@ -11,7 +11,7 @@
   "buildDirs": {
     "test": {
       "require": ["<PUBLIC_LIB_NAME>", "rely.lib"],
-      "flags": ["-linkall", "-g"]
+      "flags": ["-linkall", "-g", "-w", "-9"]
     },
     "testExe": {
       "require": ["<TEST_LIB_NAME>"],


### PR DESCRIPTION
When creating a new project it's not possible to run the `rely` tests because we're not destructuring and using all the record fields.
This PR adds the flag to ignore that issue.