### PR TITLE
More padding for longer logs

### DIFF
--- a/npm-cli/src/Spinner.re
+++ b/npm-cli/src/Spinner.re
@@ -11,7 +11,7 @@ let start = msg => {
   Js.Nullable.return(
     Js.Global.setInterval(
       () => {
-        Printf.printf("%s %s                                \r", msg, frames[i^ mod n_frames]);
+        Printf.printf("%s %s                                                                                    \r", msg, frames[i^ mod n_frames]);
         i := i^ + 1;
       },
       interval,


### PR DESCRIPTION
  'Fetching github repo' is a long log statement. Its / character is
  farthest away. When the progress indicator is rendered again, it
  doesn't get cleared

    You may now run 'esy test'                          -  
 
