### PR TITLE
Accept underscores in module path

### DIFF
--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/.gitignore
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/.gitignore
@@ -1,0 +1,11 @@
+npm-debug.log
+.merlin
+yarn-error.log
+node_modules
+node_modules/
+_build
+_release
+_esy/
+y.install
+.DS_Store
+*.install

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/dune
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/dune
@@ -1,0 +1,1 @@
+(dirs (:standard \ node_modules \ _esy))

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/dune-project
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.6)
+ (name pesy-c-stubs)

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/executable/PesyNpmApp.re
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/executable/PesyNpmApp.re
@@ -1,0 +1,2 @@
+Library.Util.foo();
+Bar.bar();

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/lib_foo/Util.re
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/lib_foo/Util.re
@@ -1,0 +1,1 @@
+let foo = () => print_endline("Hello");

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/lib_foo/foo/bar/Index.re
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/lib_foo/foo/bar/Index.re
@@ -1,0 +1,1 @@
+let bar = () => print_endline("in bar");

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "pesy-npm",
+  "version": "0.0.0",
+  "description": "My Project",
+  "esy": {
+    "build": "dune build -p #{self.name}",
+    "release": {
+      "releasedBinaries": [
+        "PesyNpmApp.exe"
+      ]
+    }
+  },
+  "buildDirs": {
+    "test": {
+      "imports": [
+        "Library = require('pesy-npm/lib_foo')"
+      ],
+      "bin": "TestPesyNpm.re"
+    },
+    "lib_foo": {},
+    "lib_foo/foo/bar": {},
+    "executable": {
+      "imports": [
+        "Bar = require('pesy-npm/lib_foo/foo/bar')",
+        "Library = require('pesy-npm/lib_foo')"
+      ],
+      "bin": {
+        "pesy-npm-app.exe": "PesyNpmApp.re"
+      }
+    }
+  },
+  "scripts": {
+    "test": "esy b dune runtest"
+  },
+  "dependencies": {
+    "ocaml": "4.7.x",
+    "@opam/dune": ">=1.6.0",
+    "@esy-ocaml/reason": "*",
+    "refmterr": "*",
+    "pesy": "*",
+    "refmterr": "*"
+  },
+  "devDependencies": {
+    "@opam/merlin": "*"
+  },
+  "resolutions": {
+    "pesy": "<RESOLUTION_LINK>"
+  }
+}

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/test/TestPesyNpm.re
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/test/TestPesyNpm.re
@@ -1,0 +1,2 @@
+Library.Util.foo();
+print_endline("Add Your Test Cases Here");

--- a/lib/Lexer.mll
+++ b/lib/Lexer.mll
@@ -10,6 +10,6 @@ rule read = parse
 | "require"  { REQUIRE }
 | ['\'']      { SQUOTE }
 | ['A' - 'Z' ] [ 'A' - 'Z' 'a' - 'z' '_'] * as lxm { MODULE_NAME(lxm)  }
-| ['@'] ? ['a'-'z' '.' '/' '-' '0'-'9'] + as lxm { MODULE_PATH(lxm)  }
+| ['@'] ? ['a'-'z' '.' '/' '-' '0'-'9' '_'] + as lxm { MODULE_PATH(lxm)  }
 | ['\n']     {EOL}
 | eof      {EOF}


### PR DESCRIPTION
As reported by @ulrikstrid , the following config would fail


```json
"buildDirs": {
    "test": {
      "imports": [
        "Library = require('morph_template/library')",
        "Rely = require('rely/lib')"
      ],
      "flags": [
        "-linkall",
        "-g",
        "-w",
        "-9"
      ]
    },
    "testExe": {
      "imports": [
        "Test = require('morph_template/test')"
      ],
      "bin": {
        "RunMorph_templateTests.exe": "RunMorph_templateTests.re"
      }
    },
    "library": {
      "imports": [
        "Opium_core = require('opium_core')",
        "Morph = require('morph')",
        "Mtime = require('mtime')",
        "Mtime_clock = require('mtime.clock.os')",
        "Logs = require('logs')",
        "Lwt = require('lwt')"
      ]
    },
    "bin": {
      "imports": [
        "Library = require('morph_template/library')",
        "Morph = require('morph')",
        "Morph_server_http = require('morph_server_http')",
        "Logs = require('logs')",
        "Logs_fmt = require('logs.fmt')",
        "Fmt_tty = require('fmt.tty')",
        "Lwt = require('lwt')",
        "Uri = require('uri')"
      ],
      "bin": {
        "Morph_templateApp.exe": "Morph_templateApp.re"
      }
    }
  },
```

Module paths need to accept underscore while parsing. 

TODO: 
1. Consult the spec and update the lexer
2. More descriptive parsing errors. (Menhir?) Also related: https://github.com/esy/pesy/issues/49