### PR TITLE
Fix regexp for MODULE_NAME and MODULE_PATH

### DIFF
--- a/lib/Lexer.mll
+++ b/lib/Lexer.mll
@@ -10,7 +10,7 @@ rule read = parse
 | ['=']      { ASSN }
 | "require"  { REQUIRE }
 | ['\'']      { SQUOTE }
-| ['A' - 'Z' ] [ 'A' - 'Z' 'a' - 'z' '_'] * as lxm { MODULE_NAME(lxm)  }
-| ['@'] ? ['a'-'z' '.' '/' '-' '0'-'9' '_'] + as lxm { MODULE_PATH(lxm)  }
+| ['A' - 'Z' ] [ 'A' - 'Z' 'a' - 'z' '_' '\'' '0'-'9'] * as lxm { MODULE_NAME(lxm)  }
+| ['@'] ? ['A'-'Z' 'a'-'z' '.' '/' '-' '0'-'9' '_'] + as lxm { MODULE_PATH(lxm)  }
 | ['\n']     {EOL}
 | eof      {EOF}


### PR DESCRIPTION
MODULE_NAME:
https://caml.inria.fr/pub/docs/manual-ocaml/lex.html#capitalized-identa

MODULE_PATH: Could be any valid unix path. Which means it could be any
non null character? In real-world it need not be that flexible - for
Windows compatibility we'll have to restrict the following

> MS-DOS, Microsoft Windows, and OS/2 disallow the characters \ / :
> ? * " > < | and NUL in file and directory names across all
> filesystems. Unices and Linux disallow the characters / and NUL in
> file and directory names across all filesystems.

Refer: https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits

And

CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5,
COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4,
LPT5, LPT6, LPT7, LPT8, LPT9

Refer: http://msdn.microsoft.com/en-us/library/aa365247.aspx

This checks haven't been performed. Additionally, even if we do wish
to fail, parser errors are not communicated well (TODO)