### PR TITLE
Fixes include_subdirs stanza generation

### DIFF
--- a/lib/Executable.re
+++ b/lib/Executable.re
@@ -156,7 +156,6 @@ let toDuneStanza = (common: Common.t, e) => {
     ocamloptFlags,
     jsooFlags,
     preprocess,
-    includeSubdirs,
   ];
 
   let rawBuildConfig =
@@ -181,6 +180,12 @@ let toDuneStanza = (common: Common.t, e) => {
     )
     @ (
       switch (pesyModulesAliasModuleGen) {
+      | Some(s) => [s]
+      | None => []
+      }
+    )
+    @ (
+      switch (includeSubdirs) {
       | Some(s) => [s]
       | None => []
       }

--- a/lib/Library.re
+++ b/lib/Library.re
@@ -152,7 +152,6 @@ let toDuneStanza = (common, lib) => {
     ocamloptFlags,
     jsooFlags,
     preprocess,
-    includeSubdirs,
   ];
 
   let rawBuildConfig =
@@ -177,6 +176,12 @@ let toDuneStanza = (common, lib) => {
     )
     @ (
       switch (pesyModulesAliasModuleGen) {
+      | Some(s) => [s]
+      | None => []
+      }
+    )
+    @ (
+      switch (includeSubdirs) {
       | Some(s) => [s]
       | None => []
       }

--- a/lib/Test.re
+++ b/lib/Test.re
@@ -156,7 +156,6 @@ let toDuneStanza = (common: Common.t, e) => {
     ocamloptFlags,
     jsooFlags,
     preprocess,
-    includeSubdirs,
     pesyModulesLibrary,
   ];
 
@@ -182,6 +181,12 @@ let toDuneStanza = (common: Common.t, e) => {
     )
     @ (
       switch (pesyModulesAliasModuleGen) {
+      | Some(s) => [s]
+      | None => []
+      }
+    )
+    @ (
+      switch (includeSubdirs) {
       | Some(s) => [s]
       | None => []
       }

--- a/lib/UnitTests.re
+++ b/lib/UnitTests.re
@@ -363,7 +363,7 @@ describe("PesyConf.testToPackages", ({test, _}) => {
       |> List.map(DuneFile.toString),
     ).
       toEqual([
-      "(library (name Foo) (public_name bar.lib) (modules (:standard))\n    (include_subdirs unqualified))\n",
+      "(library (name Foo) (public_name bar.lib) (modules (:standard)))\n(include_subdirs unqualified)\n",
     ])
   );
   test("Sample config - 12", ({expect}) =>
@@ -387,7 +387,7 @@ describe("PesyConf.testToPackages", ({test, _}) => {
       |> List.map(DuneFile.toString),
     ).
       toEqual([
-      "(library (name Foo) (public_name bar.lib) (modules (:standard))\n    (include_subdirs unqualified))\n",
+      "(library (name Foo) (public_name bar.lib) (modules (:standard)))\n(include_subdirs unqualified)\n",
     ])
   );
   test("Sample config - 14", ({expect}) =>


### PR DESCRIPTION
This addresses the generation of the `include_subdirs` stanza that was included in the library/executable/test stanza.