### PR TITLE
Add cache@2 tasks

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -13,14 +13,14 @@ steps:
   - template: utils/create-docs.yml
   - script: "esy test"
     displayName: "Test command"
-  - ${{ if eq(parameters.platform, 'Windows') }}:
+  - ${{ if eq(variables['Agent.OS'], 'Windows_NT') }}:
       - script: mkdir $(System.DefaultWorkingDirectory)\..\tests-tmp-dir
         displayName: 'Creating temporary workspace for tests'
       - script: .\_build\install\default\bin\Runner.exe
         displayName: 'Running e2e tests'
         env:
           TEMP: $(System.DefaultWorkingDirectory)\..\tests-tmp-dir
-  - ${{ if ne(parameters.platform, 'Windows') }}:
+  - ${{ if ne(variables['Agent.OS'], 'Windows_NT') }}:
       - script: ./_build/install/default/bin/Runner.exe
         displayName: 'Running e2e tests'
         env:

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -7,11 +7,9 @@ steps:
   - template: utils/use-cache-esy.yml
   - script: "esy install"
     displayName: "esy install"
-    condition: ne(variables.CACHE_RESTORED, 'true')
   - template: utils/restore-build-cache.yml # Run this to make sure cached prebuilts work. 
   - script: "esy build"
     displayName: "esy build"
-    condition: ne(variables.CACHE_RESTORED, 'true')
   - template: utils/create-docs.yml
   - script: "esy test"
     displayName: "Test command"

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -13,18 +13,19 @@ steps:
   - template: utils/create-docs.yml
   - script: "esy test"
     displayName: "Test command"
-  - ${{ if eq(variables['Agent.OS'], 'Windows_NT') }}:
-      - script: mkdir $(System.DefaultWorkingDirectory)\..\tests-tmp-dir
-        displayName: 'Creating temporary workspace for tests'
-      - script: .\_build\install\default\bin\Runner.exe
-        displayName: 'Running e2e tests'
-        env:
-          TEMP: $(System.DefaultWorkingDirectory)\..\tests-tmp-dir
-  - ${{ if ne(variables['Agent.OS'], 'Windows_NT') }}:
-      - script: ./_build/install/default/bin/Runner.exe
-        displayName: 'Running e2e tests'
-        env:
-          OCAMLRUNPARAM: 'b'
+  - script: mkdir $(System.DefaultWorkingDirectory)\..\tests-tmp-dir
+    displayName: 'Creating temporary workspace for tests'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+  - script: .\_build\install\default\bin\Runner.exe
+    displayName: 'Running e2e tests'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    env:
+      TEMP: $(System.DefaultWorkingDirectory)\..\tests-tmp-dir
+  - script: ./_build/install/default/bin/Runner.exe
+    displayName: 'Running e2e tests'
+    condition: ne(variables['Agent.OS'], 'Windows_NT')
+    env:
+      OCAMLRUNPARAM: 'b'
   - script: "esy release"
     displayName: "esy release"
   - template: utils/publish-build-cache.yml

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -2,12 +2,16 @@
 
 steps:
   - template: utils/use-node.yml
+  - template: utils/use-cache-npm.yml
   - template: utils/use-esy.yml
+  - template: utils/use-cache-esy.yml
   - script: "esy install"
     displayName: "esy install"
-  - template: utils/restore-build-cache.yml
+    condition: ne(variables.CACHE_RESTORED, 'true')
+  - template: utils/restore-build-cache.yml # Run this to make sure cached prebuilts work. 
   - script: "esy build"
     displayName: "esy build"
+    condition: ne(variables.CACHE_RESTORED, 'true')
   - template: utils/create-docs.yml
   - script: "esy test"
     displayName: "Test command"

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -2,7 +2,7 @@
 
 steps:
   - template: utils/use-node.yml
-  - template: utils/use-cache-npm.yml
+  # - template: utils/use-cache-npm.yml
   - template: utils/use-esy.yml
   - template: utils/use-cache-esy.yml
   - script: "esy install"

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -13,6 +13,18 @@ steps:
   - template: utils/create-docs.yml
   - script: "esy test"
     displayName: "Test command"
+  - ${{ if eq(parameters.platform, 'Windows') }}:
+      - script: mkdir $(System.DefaultWorkingDirectory)\..\tests-tmp-dir
+        displayName: 'Creating temporary workspace for tests'
+      - script: .\_build\install\default\bin\Runner.exe
+        displayName: 'Running e2e tests'
+        env:
+          TEMP: $(System.DefaultWorkingDirectory)\..\tests-tmp-dir
+  - ${{ if ne(parameters.platform, 'Windows') }}:
+      - script: ./_build/install/default/bin/Runner.exe
+        displayName: 'Running e2e tests'
+        env:
+          OCAMLRUNPARAM: 'b'
   - script: "esy release"
     displayName: "esy release"
   - template: utils/publish-build-cache.yml

--- a/.ci/utils/use-cache-esy.yml
+++ b/.ci/utils/use-cache-esy.yml
@@ -1,4 +1,6 @@
 steps:
+  - bash: env
+    displayName: "Print environment"
   - task: Cache@2
     condition: and(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))
     inputs:

--- a/.ci/utils/use-cache-esy.yml
+++ b/.ci/utils/use-cache-esy.yml
@@ -1,6 +1,6 @@
 steps:
   - task: Cache@2
-    condition: and(eq(variables['Build.Reason'], 'PullRequest'), and(ne(variables['Agent.OS'], 'Windows_NT'), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch'])))
+    condition: and(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))
     inputs:
       key: 'vPrimary | esy | "$(Agent.OS)" | "$(Build.SourcesDirectory)/npm-cli/package-lock.json"' # vPrimary, here, is just a way to bust cache during debugging. Inspired from https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#can-i-clear-a-cache" 
       path: $(HOME)/.esy

--- a/.ci/utils/use-cache-esy.yml
+++ b/.ci/utils/use-cache-esy.yml
@@ -2,7 +2,7 @@ steps:
   - task: Cache@2
     condition: and(eq(variables['Build.Reason'], 'PullRequest'), and(ne(variables['Agent.OS'], 'Windows_NT'), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch'])))
     inputs:
-      key: 'vPrimary | package.json | "$(Agent.OS)"' # vPrimary, here, is just a way to bust cache during debugging. Inspired from https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#can-i-clear-a-cache" 
+      key: 'vPrimary | esy | "$(Agent.OS)" | "$(Build.SourcesDirectory)/npm-cli/package-lock.json"' # vPrimary, here, is just a way to bust cache during debugging. Inspired from https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#can-i-clear-a-cache" 
       path: $(HOME)/.esy
       cacheHitVar: CACHE_RESTORED
     displayName:  Cache ~/.esy

--- a/.ci/utils/use-cache-esy.yml
+++ b/.ci/utils/use-cache-esy.yml
@@ -2,7 +2,7 @@ steps:
   - task: Cache@2
     condition: and(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))
     inputs:
-      key: 'vPrimary | esy | "$(Agent.OS)" | "$(Build.SourcesDirectory)/npm-cli/package-lock.json"' # vPrimary, here, is just a way to bust cache during debugging. Inspired from https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#can-i-clear-a-cache" 
-      path: $(HOME)/.esy
+      key: 'vPrimary | esy | "$(Agent.OS)" | "$(Build.SourcesDirectory)/esy.lock/index.json"' # vPrimary, here, is just a way to bust cache during debugging. Inspired from https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#can-i-clear-a-cache" 
+      path: $(THE_ESY__CACHE_INSTALL_PATH)
       cacheHitVar: CACHE_RESTORED
-    displayName:  Cache ~/.esy
+    displayName:  "Caching $(THE_ESY__CACHE_INSTALL_PATH)"

--- a/.ci/utils/use-cache-esy.yml
+++ b/.ci/utils/use-cache-esy.yml
@@ -1,0 +1,7 @@
+  - task: Cache@2
+    condition: and(eq(variables['Build.Reason'], 'PullRequest'), and(ne(variables['Agent.OS'], 'Windows_NT'), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch'])))
+    inputs:
+      key: 'vPrimary | .esy | "$(Agent.OS)"' # vPrimary, here, is just a way to bust cache during debugging. Inspired from https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#can-i-clear-a-cache" 
+      path: $(HOME)/.esy
+      cacheHitVar: CACHE_RESTORED
+    displayName:  Cache ~/.esy

--- a/.ci/utils/use-cache-esy.yml
+++ b/.ci/utils/use-cache-esy.yml
@@ -1,3 +1,4 @@
+steps:
   - task: Cache@2
     condition: and(eq(variables['Build.Reason'], 'PullRequest'), and(ne(variables['Agent.OS'], 'Windows_NT'), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch'])))
     inputs:

--- a/.ci/utils/use-cache-esy.yml
+++ b/.ci/utils/use-cache-esy.yml
@@ -2,7 +2,7 @@ steps:
   - task: Cache@2
     condition: and(eq(variables['Build.Reason'], 'PullRequest'), and(ne(variables['Agent.OS'], 'Windows_NT'), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch'])))
     inputs:
-      key: 'vPrimary | .esy | "$(Agent.OS)"' # vPrimary, here, is just a way to bust cache during debugging. Inspired from https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#can-i-clear-a-cache" 
+      key: 'vPrimary | package.json | "$(Agent.OS)"' # vPrimary, here, is just a way to bust cache during debugging. Inspired from https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#can-i-clear-a-cache" 
       path: $(HOME)/.esy
       cacheHitVar: CACHE_RESTORED
     displayName:  Cache ~/.esy

--- a/.ci/utils/use-cache-esy.yml
+++ b/.ci/utils/use-cache-esy.yml
@@ -1,10 +1,8 @@
 steps:
-  - bash: env
-    displayName: "Print environment"
   - task: Cache@2
     condition: and(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))
     inputs:
       key: 'vPrimary | esy | "$(Agent.OS)" | "$(Build.SourcesDirectory)/esy.lock/index.json"' # vPrimary, here, is just a way to bust cache during debugging. Inspired from https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#can-i-clear-a-cache" 
-      path: $(THE_ESY__CACHE_INSTALL_PATH)
+      path: $(ESY__CACHE_INSTALL_PATH)
       cacheHitVar: CACHE_RESTORED
-    displayName:  "Caching $(THE_ESY__CACHE_INSTALL_PATH)"
+    displayName:  "Caching $(ESY__CACHE_INSTALL_PATH)"

--- a/.ci/utils/use-cache-esy.yml
+++ b/.ci/utils/use-cache-esy.yml
@@ -2,7 +2,7 @@ steps:
   - task: Cache@2
     condition: and(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))
     inputs:
-      key: 'vPrimary | esy | "$(Agent.OS)" | "$(Build.SourcesDirectory)/esy.lock/index.json"' # vPrimary, here, is just a way to bust cache during debugging. Inspired from https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#can-i-clear-a-cache" 
+      key: 'v1 | esy | "$(Agent.OS)" | "$(Build.SourcesDirectory)/esy.lock/index.json"' # vPrimary, here, is just a way to bust cache during debugging. Inspired from https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#can-i-clear-a-cache" 
       path: $(ESY__CACHE_INSTALL_PATH)
       cacheHitVar: CACHE_RESTORED
     displayName:  "Caching $(ESY__CACHE_INSTALL_PATH)"

--- a/.ci/utils/use-cache-npm.yml
+++ b/.ci/utils/use-cache-npm.yml
@@ -5,5 +5,5 @@ steps:
     restoreKeys: |
        npm | "$(Agent.OS)"
        npm
-    path: $(Pipeline.Workspace)/.npm
+    path: $(HOME)/.npm
   displayName: Cache npm

--- a/.ci/utils/use-cache-npm.yml
+++ b/.ci/utils/use-cache-npm.yml
@@ -7,3 +7,13 @@ steps:
        npm
     path: $(HOME)/.npm
   displayName: Cache npm
+  condition: ne(variables['AGENT.OS'], 'Windows_NT')
+- task: Cache@2
+  inputs:
+    key: 'npm | "$(Agent.OS)" | "$(Build.SourcesDirectory)/npm-cli/package-lock.json"'
+    restoreKeys: |
+       npm | "$(Agent.OS)"
+       npm
+    path: $(AppData)/npm-cache
+  displayName: Cache npm
+  condition: eq(variables['AGENT.OS'], 'Windows_NT')

--- a/.ci/utils/use-cache-npm.yml
+++ b/.ci/utils/use-cache-npm.yml
@@ -1,6 +1,3 @@
-variables:
-  npm_config_cache: $(Pipeline.Workspace)/.npm
-
 steps:
 - task: Cache@2
   inputs:
@@ -8,5 +5,5 @@ steps:
     restoreKeys: |
        npm | "$(Agent.OS)"
        npm
-    path: $(npm_config_cache)
+    path: $(Pipeline.Workspace)/.npm
   displayName: Cache npm

--- a/.ci/utils/use-cache-npm.yml
+++ b/.ci/utils/use-cache-npm.yml
@@ -1,0 +1,12 @@
+variables:
+  npm_config_cache: $(Pipeline.Workspace)/.npm
+
+steps:
+- task: Cache@2
+  inputs:
+    key: 'npm | "$(Agent.OS)" | "$(Build.SourcesDirectory)/npm-cli/package-lock.json"'
+    restoreKeys: |
+       npm | "$(Agent.OS)"
+       npm
+    path: $(npm_config_cache)
+  displayName: Cache npm

--- a/e2e-tests/TestPesyConfigure.re
+++ b/e2e-tests/TestPesyConfigure.re
@@ -144,7 +144,11 @@ List.iter(
 
     Printf.printf("Running `esy install`");
     print_newline();
-    let exitStatus = runCommandWithEnv(esyCommand, [|"install"|]);
+    let exitStatus =
+      runCommandWithEnv(
+        esyCommand,
+        [|"install", "--skip-repository-update"|],
+      );
     if (exitStatus != 0) {
       Printf.fprintf(
         stderr,

--- a/e2e-tests/pesy-configure-test-projects/pesy-4.6/executable/PesyNpmApp.ml
+++ b/e2e-tests/pesy-configure-test-projects/pesy-4.6/executable/PesyNpmApp.ml
@@ -1,0 +1,2 @@
+;;Library.Util.foo ()
+;;Bar.bar ()

--- a/e2e-tests/pesy-configure-test-projects/pesy-4.6/executable/PesyNpmApp.re
+++ b/e2e-tests/pesy-configure-test-projects/pesy-4.6/executable/PesyNpmApp.re
@@ -1,2 +1,0 @@
-Library.Util.foo();
-Bar.bar();

--- a/e2e-tests/pesy-configure-test-projects/pesy-4.6/library/Util.ml
+++ b/e2e-tests/pesy-configure-test-projects/pesy-4.6/library/Util.ml
@@ -1,0 +1,1 @@
+let foo () = print_endline "Hello"

--- a/e2e-tests/pesy-configure-test-projects/pesy-4.6/library/Util.re
+++ b/e2e-tests/pesy-configure-test-projects/pesy-4.6/library/Util.re
@@ -1,1 +1,0 @@
-let foo = () => print_endline("Hello");

--- a/e2e-tests/pesy-configure-test-projects/pesy-4.6/library/foo/bar/Index.ml
+++ b/e2e-tests/pesy-configure-test-projects/pesy-4.6/library/foo/bar/Index.ml
@@ -1,0 +1,1 @@
+let bar () = print_endline "in bar"

--- a/e2e-tests/pesy-configure-test-projects/pesy-4.6/library/foo/bar/Index.re
+++ b/e2e-tests/pesy-configure-test-projects/pesy-4.6/library/foo/bar/Index.re
@@ -1,1 +1,0 @@
-let bar = () => print_endline("in bar");

--- a/e2e-tests/pesy-configure-test-projects/pesy-4.6/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-4.6/package.json
@@ -35,13 +35,7 @@
   "dependencies": {
     "ocaml": "4.6.x",
     "@opam/dune": ">=1.6.0",
-    "@esy-ocaml/reason": "*",
-    "refmterr": "*",
-    "pesy": "*",
-    "refmterr": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
+    "pesy": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/pesy-4.6/test/TestPesyNpm.ml
+++ b/e2e-tests/pesy-configure-test-projects/pesy-4.6/test/TestPesyNpm.ml
@@ -1,0 +1,2 @@
+;;Library.Util.foo ()
+;;print_endline "Add Your Test Cases Here"

--- a/e2e-tests/pesy-configure-test-projects/pesy-4.6/test/TestPesyNpm.re
+++ b/e2e-tests/pesy-configure-test-projects/pesy-4.6/test/TestPesyNpm.re
@@ -1,2 +1,0 @@
-Library.Util.foo();
-print_endline("Add Your Test Cases Here");

--- a/e2e-tests/pesy-configure-test-projects/pesy-4.8/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-4.8/package.json
@@ -35,13 +35,8 @@
   "dependencies": {
     "ocaml": "4.8.x",
     "@opam/dune": ">=1.6.0",
-    "@esy-ocaml/reason": "*",
-    "refmterr": "*",
     "pesy": "*",
-    "refmterr": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
+    "@esy-ocaml/reason": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/pesy-c-stubs/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-c-stubs/package.json
@@ -37,15 +37,10 @@
     "test": "esy b dune runtest"
   },
   "dependencies": {
-    "ocaml": "4.7.x",
+    "ocaml": "4.8.x",
     "@opam/dune": ">=1.6.0",
     "@esy-ocaml/reason": "*",
-    "refmterr": "*",
-    "pesy": "*",
-    "refmterr": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
+    "pesy": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/pesy-flags/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-flags/package.json
@@ -38,14 +38,10 @@
     "test": "esy b dune runtest"
   },
   "dependencies": {
-    "ocaml": "4.7.x",
+    "ocaml": "4.8.x",
     "@opam/dune": ">=1.6.0",
     "@esy-ocaml/reason": "*",
-    "refmterr": "*",
     "pesy": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/pesy-modes/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-modes/package.json
@@ -46,14 +46,10 @@
     "test": "esy b dune runtest"
   },
   "dependencies": {
-    "ocaml": "4.7.x",
+    "ocaml": "4.8.x",
     "@opam/dune": ">=1.6.0",
     "@esy-ocaml/reason": "*",
-    "refmterr": "*",
     "pesy": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-lib-entry/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-lib-entry/package.json
@@ -38,13 +38,8 @@
   "dependencies": {
     "@opam/dune": ">=1.6.0",
     "@esy-ocaml/reason": "*",
-    "refmterr": "*",
-    "ocaml": "4.7.x",
-    "pesy": "*",
-    "refmterr": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
+    "ocaml": "4.8.x",
+    "pesy": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-relative/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-relative/package.json
@@ -37,15 +37,10 @@
     "test": "esy b dune runtest"
   },
   "dependencies": {
-    "ocaml": "4.7.x",
+    "ocaml": "4.8.x",
     "@opam/dune": ">=1.6.0",
     "@esy-ocaml/reason": "*",
-    "refmterr": "*",
-    "pesy": "*",
-    "refmterr": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
+    "pesy": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-scoped/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-scoped/package.json
@@ -33,15 +33,10 @@
     "test": "esy b dune runtest"
   },
   "dependencies": {
-    "ocaml": "4.7.x",
+    "ocaml": "4.8.x",
     "@opam/dune": ">=1.6.0",
     "@esy-ocaml/reason": "*",
-    "refmterr": "*",
-    "pesy": "*",
-    "refmterr": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
+    "pesy": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-with-lwt-sample/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-with-lwt-sample/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@esy-ocaml/reason": "*",
     "@opam/dune": "*",
-    "@opam/lwt": "4.1.0",
+    "@opam/lwt": "5.1.1",
     "@opam/lwt_ppx": "1.2.1",
     "ocaml": "4.8.x",
     "pesy": "*"

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-with-lwt-sample/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-with-lwt-sample/package.json
@@ -41,12 +41,8 @@
     "@opam/dune": "*",
     "@opam/lwt": "4.1.0",
     "@opam/lwt_ppx": "1.2.1",
-    "ocaml": "4.7.x",
-    "pesy": "*",
-    "refmterr": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
+    "ocaml": "4.8.x",
+    "pesy": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm-with-underscore/package.json
@@ -33,12 +33,10 @@
     "test": "esy b dune runtest"
   },
   "dependencies": {
-    "ocaml": "4.7.x",
+    "ocaml": "4.8.x",
     "@opam/dune": ">=1.6.0",
     "@esy-ocaml/reason": "*",
-    "refmterr": "*",
-    "pesy": "*",
-    "refmterr": "*"
+    "pesy": "*"
   },
   "devDependencies": {
     "@opam/merlin": "*"

--- a/e2e-tests/pesy-configure-test-projects/pesy-npm/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-npm/package.json
@@ -33,15 +33,10 @@
     "test": "esy b dune runtest"
   },
   "dependencies": {
-    "ocaml": "4.7.x",
+    "ocaml": "4.8.x",
     "@opam/dune": ">=1.6.0",
     "@esy-ocaml/reason": "*",
-    "refmterr": "*",
-    "pesy": "*",
-    "refmterr": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
+    "pesy": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/pesy-preprocess/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-preprocess/package.json
@@ -40,16 +40,12 @@
     "test": "esy b dune runtest"
   },
   "dependencies": {
-    "ocaml": "4.7.x",
+    "ocaml": "4.8.x",
     "@esy-ocaml/reason": "*",
     "@opam/dune": ">=1.6.0",
     "@opam/lwt": "4.1.0",
     "@opam/lwt_ppx": "1.2.1",
-    "pesy": "*",
-    "refmterr": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
+    "pesy": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/pesy-preprocess/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-preprocess/package.json
@@ -43,7 +43,7 @@
     "ocaml": "4.8.x",
     "@esy-ocaml/reason": "*",
     "@opam/dune": ">=1.6.0",
-    "@opam/lwt": "4.1.0",
+    "@opam/lwt": "5.1.1",
     "@opam/lwt_ppx": "1.2.1",
     "pesy": "*"
   },

--- a/e2e-tests/pesy-configure-test-projects/pesy-virtual/package.json
+++ b/e2e-tests/pesy-configure-test-projects/pesy-virtual/package.json
@@ -57,14 +57,10 @@
     "test": "esy x PesyVirtualAppBar.exe"
   },
   "dependencies": {
-    "ocaml": "4.7.x",
+    "ocaml": "4.8.x",
     "dune": "*",
     "@esy-ocaml/reason": "*",
-    "pesy": "*",
-    "refmterr": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
+    "pesy": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/raw/package.json
+++ b/e2e-tests/pesy-configure-test-projects/raw/package.json
@@ -42,15 +42,12 @@
     "test": "esy b dune runtest"
   },
   "dependencies": {
+    "ocaml": "4.8.x",
     "@esy-ocaml/reason": "*",
     "@opam/dune": "*",
     "@opam/lwt": "4.1.0",
     "@opam/lwt_ppx": "1.2.1",
-    "pesy": "*",
-    "refmterr": "*"
-  },
-  "devDependencies": {
-    "@opam/merlin": "*"
+    "pesy": "*"
   },
   "resolutions": {
     "pesy": "<RESOLUTION_LINK>"

--- a/e2e-tests/pesy-configure-test-projects/raw/package.json
+++ b/e2e-tests/pesy-configure-test-projects/raw/package.json
@@ -45,7 +45,7 @@
     "ocaml": "4.8.x",
     "@esy-ocaml/reason": "*",
     "@opam/dune": "*",
-    "@opam/lwt": "4.1.0",
+    "@opam/lwt": "5.1.1",
     "@opam/lwt_ppx": "1.2.1",
     "pesy": "*"
   },

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5e798c6f5a0ba599efe40441c7418af7",
+  "checksum": "24bc830d8a17d389f63f9d459ff9ace2",
   "root": "@pesy/esy-pesy@link-dev:./package.json",
   "node": {
     "refmterr@3.3.0@d41d8cd9": {

--- a/npm-cli/package-lock.json
+++ b/npm-cli/package-lock.json
@@ -2294,7 +2294,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2315,12 +2316,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2335,17 +2338,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2462,7 +2468,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2474,6 +2481,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2488,6 +2496,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2495,12 +2504,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2519,6 +2530,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2608,7 +2620,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2620,6 +2633,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2705,7 +2719,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2741,6 +2756,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2760,6 +2776,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2803,12 +2820,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "ocaml": "4.6.10 - 4.8"
   },
   "devDependencies": {
-    "ocaml": "4.6.10 - 4.8",
+    "ocaml": "4.8.x",
     "@opam/odoc": "*",
     "pesy-self": "*",
     "refmterr": "*",


### PR DESCRIPTION
e2e tests run extremely slowly since the entire ~/.esy directory is not cached with the `esy import-dependencies` approach. We cache the entire ~/.esy directory using Azure Pipelines's cache@2 tasks, but retains the earlier restore/publish steps to ensure we can still publish and consume relocatable esy artifacts

TODO
- [x] get back e2e tests
- [x] Use `--skip-repository-update` 