### PR TITLE
CI: Use macos-latest

### DIFF
--- a/.ci/build-platform.yml
+++ b/.ci/build-platform.yml
@@ -1,6 +1,6 @@
 parameters:
   platform: "macOS"
-  vmImage: "macOS-10.13"
+  vmImage: "macOS-latest"
 
 jobs:
   - job: ${{ parameters.platform }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
   - template: .ci/build-platform.yml
     parameters:
       platform: macOS
-      vmImage: macOS-10.13
+      vmImage: macOS-latest
 
   # Need windows-2019 to do esy import/export-dependencies
   # which assumes you have bsdtar (tar.exe) in your system
@@ -37,7 +37,7 @@ jobs:
       - macOS
       - Windows
     pool:
-      vmImage: macOS-10.13
+      vmImage: macOS-latest
       demands: node.js
     steps:
       - template: .ci/cross-release.yml

--- a/npm-cli/v0.4.4/azure-ci-template/azure-pipelines.yml
+++ b/npm-cli/v0.4.4/azure-ci-template/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
 - job: MacOS
   timeoutInMinutes: 0
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: 'macOS-latest'
 
   variables:
     ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i/


### PR DESCRIPTION
Replaced all `macos-10.13` to `latest` version.

See: https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/

I'm not sure though that it was required in the `npm-cli/v0.4.4` folder?