### PR TITLE
fix dune-file path

### DIFF
--- a/lib/Lib.re
+++ b/lib/Lib.re
@@ -124,7 +124,8 @@ let duneFile = (projectPath, manifestFile, subpackagePath) => {
   List.iter(
     dpkg => {
       let (path, duneFile) = dpkg;
-      if (path |> normalize == (subpackagePath |> normalize)) {
+      if (path
+          |> normalize == (Path.(projectPath / subpackagePath) |> normalize)) {
         print_endline(DuneFile.toString(duneFile));
       } else {
         ();


### PR DESCRIPTION
`dune-file` command was not working for me.

`subpackagePath` is only the name of the folder we want to generate the dune config for (e.g `bin` or `library`). We actually need to prepend it with the `projectPath` to compute the full path and compare it to the dune file path.

EDIT: Well, if we give `dune-file` the full path of the directory, it works. But I personally find it easier to just give the directory name instead of the full path.

What do you think ?