### PR TITLE
Better support for namespaced NPM dependencies

### DIFF
--- a/.ci/build-platform.yml
+++ b/.ci/build-platform.yml
@@ -16,10 +16,10 @@ jobs:
       # Needed so that the mingw tar doesn't shadow the system tar. See
       # pipelines.yaml. We need windows bsdtar from system32, not the mingw
       # one. Note powershell doesn't need escaping of backslashes.
-      - powershell: Write-Host "##vso[task.setvariable variable=PATH;]C:\Windows\system32;${env:PATH}"
+      - powershell: Write-Host "##vso[task.setvariable variable=PATH;]C:\Program Files\Git\bin;C:\Windows\system32;${env:PATH}"
         continueOnError: true
         condition: eq(variables['AGENT.OS'], 'Windows_NT')
-        displayName: "Make sure windows/system32 is at front of path if windows"
+        displayName: "Make sure C:/Program Files/Git/bin and windows/system32 is at front of path if windows"
       - powershell: $Env:Path
         continueOnError: true
         condition: and(eq(variables['AGENT.OS'], 'Windows_NT'), and(eq(variables['Build.Reason'], 'PullRequest'), and(succeeded(), ne(variables['Build.SourceBranch'], variables['System.PullRequest.TargetBranch']))))

--- a/e2e-tests/Runner.re
+++ b/e2e-tests/Runner.re
@@ -574,6 +574,7 @@ Foo.foo();
               Fpath.(v(cwd) / "executable-with-lwt-preprocess" / "Main.re"),
               {|
 open Lwt;
+Console.log("Testing..");
 let foo = {
   let%lwt foo = Lwt.return("hello world from lwt");
   Lwt.return(foo ++ " blah");
@@ -590,8 +591,9 @@ print_endline(Lwt_main.run(foo));
                            {
                                "executable-with-lwt-preprocess": {
                                  "imports": [
+                                   "Console = require('@reason-native/console/lib')",
                                    "Lwt = require('lwt')",
-       "LwtUnix = require('lwt/unix')"
+                                   "LwtUnix = require('lwt/unix')"
                                  ],
                                 "preprocess": [
                                     "pps",

--- a/lib/Lib.re
+++ b/lib/Lib.re
@@ -123,7 +123,7 @@ let duneFile = (projectPath, manifestFile, subpackagePath) => {
   let rootName = PesyConf.rootName(conf);
   let pesyPackages =
     pkgs |> List.map(PesyConf.toPesyConf(projectPath, rootName));
-
+  /** TODO: Why compute for every subpackage? */
   PesyConf.(
     switch (
       pesyPackages
@@ -140,7 +140,7 @@ let duneFile = (projectPath, manifestFile, subpackagePath) => {
     | Some(pesyPackage) =>
       let (_, duneFile) =
         PesyConf.toDunePackages(projectPath, rootName, pesyPackage);
-      print_endline(DuneFile.toString(duneFile));
+      DuneFile.toString(duneFile) |> print_endline;
     }
   );
 };


### PR DESCRIPTION
We only support direct import of libraries only when they were written with pesy or following pesy convention. Example: @foo/bar library was expected to have it's opam file by the name foo--bar and it's respective sub-libraries as foo-bar.baz etc. Although extremely useful to follow such conventions (particularly wrt namespacing on NPM), it limited imports to work only with other libraries that were written with pesy.

This PR makes no such assumption and uses findlib to lookup the correct library name and enables use of existing libraries with pesy that need not follow pesy conventions or have used pesy to publish them.

Example import statement

```json
"imports": [ "Console = require('@reason-native/console/lib')" ]
```