### PR TITLE
Fix bracket for sandbox command

### DIFF
--- a/README.html
+++ b/README.html
@@ -174,7 +174,7 @@ we strongly recommended that you always commit them.
 > package (Eject them).
 
 In case, you need to re-generate them, run `esy pesy` (or `esy
-@mysandbox pesy`) if you are using `esy` sandboxes.
+@mysandbox pesy` if you are using `esy` sandboxes).
 
 #### Ejecting:
 


### PR DESCRIPTION
The bracket was in a place where it appeared that both `esy pesy` 
and `esy @mysandbox pesy` were for sandbox usage but if I understand
correctly, that's not the case. Moving the bracket makes that clearer.