### PR TITLE
Resolve ambiguities for multiple candidates

### DIFF
--- a/lib/PesyConf.re
+++ b/lib/PesyConf.re
@@ -156,7 +156,7 @@ to
     Str.split(Str.regexp(Sys.unix ? ":" : ";"), ocamlpath)
     |> List.filter_map(v =>
          if (Str.string_match(
-               Str.regexp(".*" ++ esyfiedDepName ++ ".*"),
+               Str.regexp(".*" ++ esyfiedDepName ++ "-.*"),
                v,
                0,
              )) {


### PR DESCRIPTION
Issue: pesy incorrectly showed @opam/result and @opam/re
for @opam/re as candidates