### PR TITLE
Use dev version

### DIFF
--- a/bin/Pesy.re
+++ b/bin/Pesy.re
@@ -245,7 +245,7 @@ let pesyLsLibs = () => {
     pkgs,
   );
 };
-let version = "0.1.0-alpha.13";
+let version = "0.1.0-dev.14";
 
 let cmd = () => {
   open Cmdliner.Term;

--- a/e2e-tests/Runner.re
+++ b/e2e-tests/Runner.re
@@ -47,7 +47,7 @@ let () = {
   run(makeCommand("yarn"), [||]);
   run(makeCommand("yarn"), [|"run", "package"|]);
   run(makeCommand("npm"), [|"pack"|]);
-  run(makeCommand("npm"), [|"i", "-g", "./pesy-0.5.0-alpha.22.tgz"|]);
+  run(makeCommand("npm"), [|"i", "-g", "./pesy-0.5.0-dev.23.tgz"|]);
   chdir(cwd);
 };
 

--- a/npm-cli/package.json
+++ b/npm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pesy",
-  "version": "0.5.0-alpha.22",
+  "version": "0.5.0-dev.23",
   "bin": {
     "pesy": "pesy"
   },

--- a/npm-cli/src/Pesy.re
+++ b/npm-cli/src/Pesy.re
@@ -130,7 +130,7 @@ let upgradeTemplate = (dest, cs1, cs2) => {
   |> Js.Promise.then_(_ => Js.log("") |> Js.Promise.resolve);
 };
 
-let version = "0.5.0-alpha.22";
+let version = "0.5.0-dev.23";
 let template = {
   let doc = "Specify URL of the remote template. This can be of the form https://repo-url.git#<commit|branch|tag>. Eg: https://github.com/reason-native-web/morph-hello-world-pesy-template#6e5cbbb9f28";
   Arg.(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pesy/esy-pesy",
-  "version": "0.1.0-alpha.13",
+  "version": "0.1.0-dev.14",
   "description": "\"Esy Pesy\" - Your Esy Assistant.",
   "esy": {
     "buildsInSource": "_build",

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -2,6 +2,6 @@ call esy build
 call esy npm-release
 call cd _release
 call npm pack
-call npm install -g ./pesy-0.5.0-alpha.22.tgz
+call npm install -g ./pesy-0.5.0-dev.23.tgz
 call cd ..
 call .\_build\install\default\bin\TestPesyConfigure.exe

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,7 +6,7 @@ root=$PWD
 custom_registry_url=http://localhost:4873
 original_npm_registry_url=https://registry.npmjs.org # `npm get registry`
 original_yarn_registry_url=https://registry.yarnpkg.com # `yarn config get registry`
-version=0.5.0-alpha.22
+version=0.5.0-dev.23
 
 
 function cleanup {


### PR DESCRIPTION
TODO: Add a convenient alternative to `git ls-files | xargs sed -i 's/alpha.22/dev.23/g'` to make such string replacements

`dune substs` doesn't work for us since those edits are in-source and we cant check into `%{VERSION}` into the git repository. (Atleast not for now)