### PR TITLE
Closes readline interface on invalid inputs

### DIFF
--- a/npm-cli/src/Utils.re
+++ b/npm-cli/src/Utils.re
@@ -153,7 +153,9 @@ let rec askYesNoQuestion = (~question, ~onYes, ~onNo, ()) => {
       | "no" =>
         onNo();
         rl##close();
-      | _ => askYesNoQuestion(~question, ~onYes, ~onNo, ())
+      | _ =>
+        askYesNoQuestion(~question, ~onYes, ~onNo, ());
+        rl##close();
       };
     },
   );

--- a/npm-cli/src/Utils.re
+++ b/npm-cli/src/Utils.re
@@ -154,8 +154,8 @@ let rec askYesNoQuestion = (~question, ~onYes, ~onNo, ()) => {
         onNo();
         rl##close();
       | _ =>
-        askYesNoQuestion(~question, ~onYes, ~onNo, ());
         rl##close();
+        askYesNoQuestion(~question, ~onYes, ~onNo, ());
       };
     },
   );


### PR DESCRIPTION
Issue: Entering invalid input shows the prompt again but since the previous interface was not closed, it prints any key you type, twice.

![part-2020_12_02_17_59_14](https://user-images.githubusercontent.com/11407672/100872768-550dbf80-34c8-11eb-89ea-6020e4201662.jpg)

Solution: Close the readline interface